### PR TITLE
store pointer to parent in TapeNodes instead of pushing to a tape stack

### DIFF
--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -1,0 +1,15 @@
+using ReverseDiffPrototype
+
+function rosenbrock(x)
+    a = one(eltype(x))
+    b = 100 * a
+    result = zero(eltype(x))
+    for i in 1:length(x)-1
+        result += (a - x[i])^2 + b*(x[i+1] - x[i]^2)^2
+    end
+    return result
+end
+
+x = rand(100000);
+out = zeros(x);
+g! = ReverseDiffPrototype.gradient(rosenbrock, Input{Float64,100000});


### PR DESCRIPTION
@mlubin So is this what you meant by generating a graph instead of storing a tape? GC time is now a huge factor, since it becomes the GC's job to free the nodes after back-propagation happens.


Using my usual microbenchmark: 

```julia
using ReverseDiffPrototype

function rosenbrock(x)
    a = one(eltype(x))
    b = 100 * a
    result = zero(eltype(x))
    for i in 1:length(x)-1
        result += (a - x[i])^2 + b*(x[i+1] - x[i]^2)^2
    end
    return result
end

x = rand(100000);
out = zeros(x);
g! = ReverseDiffPrototype.gradient(rosenbrock, Input{Float64,100000});
```

On master:

```julia
julia> @time g!(out, x);
  3.108355 seconds (4.50 M allocations: 120.544 MB, 7.68% gc time)
```

With this PR:

```julia
julia> @time g!(out, x);
  0.267648 seconds (3.40 M allocations: 103.759 MB, 53.69% gc time)
```

The target function's runtime:

```julia
julia> using BenchmarkTools

julia> @benchmark rosenbrock($x)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     155.66 μs (0.00% GC)
  median time:      155.80 μs (0.00% GC)
  mean time:        156.89 μs (0.00% GC)
  maximum time:     355.14 μs (0.00% GC)
```

We're still pretty slow vs. the target function ( ~1700x), but a bit faster than we used to be. From preliminary benchmarking, that improvement might get better the higher the input dimension:

```julia
julia> @time g!(out, x) # on master, length(x) = 1,000,000
 31.253529 seconds (45.00 M allocations: 1.177 GB, 3.49% gc time)
```

```julia
julia> @time g!(out, x);
  1.558430 seconds (34.00 M allocations: 1.013 GB, 37.29% gc time)
```

So at `length(x) == 100,000`, this PR demonstrates a ~10x speedup over master,  and at `length(x) == 1,000,000`, this PR demonstrates a ~20x speedup over master.
