### PR TITLE
Use generated function instead of `eval` for registering types to tape heads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,12 @@ os:
   - linux
   - osx
 julia:
-  - release
   - nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiffPrototype"); Pkg.test("ReverseDiffPrototype"; coverage=true)'
+script:
+ - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+ - julia -e 'Pkg.clone(pwd()); Pkg.build("ReverseDiffPrototype"); Pkg.test("ReverseDiffPrototype"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("ReverseDiffPrototype")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("ReverseDiffPrototype")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/src/ReverseDiffPrototype.jl
+++ b/src/ReverseDiffPrototype.jl
@@ -3,95 +3,113 @@ module ReverseDiffPrototype
 using ForwardDiff
 import Calculus
 
-abstract Input{T,N}
-abstract Tag{F,T,N}
-
-export Input
-
 ######################
 # Tape-related Types #
 ######################
 
+# tape storage #
+#--------------#
+
+immutable TapeNode{F,I,O}
+    f::F
+    input::I
+    output::O
+    parent
+end
+
+type TapeHead
+    node::TapeNode
+end
+
+const INITIAL_NODE = TapeNode(nothing, nothing, nothing, nothing)
+
+isinit(node::TapeNode) = node === INITIAL_NODE
+isinit(head::TapeHead) = isinit(head.node)
+
 # value types #
 #-------------#
 
-type TapeReal{tag,T<:Real} <: Real
+type TapeReal{F,T<:Real} <: Real
     val::T
     adj::T
 end
 
-typealias TapeValue{tag,T} Union{TapeReal{tag,T}, Array{TapeReal{tag,T}}}
+# always provide type parameters when using these aliases for overloading
+typealias TapeArray{F,T,N} AbstractArray{TapeReal{F,T},N}
 
-TapeReal{tag<:Tag,T}(::Type{tag}, val::T) = TapeReal{tag,T}(val)
-
+@inline numtype{F,T}(::Type{TapeReal{F,T}}) = T
 @inline value(n::TapeReal) = n.val
 @inline adjoint(n::TapeReal) = n.adj
 
-# we can't use map here because we'll overload it below to record all ops
-@inline function value{tag,T<:Real}(A::Array{TapeReal{tag,T}})
-    out = similar(A, T)
-    for i in eachindex(A)
-        out[i] = value(A[i])
-    end
-    return out
-end
-@inline function adjoint{tag,T<:Real}(A::Array{TapeReal{tag,T}})
-    out = similar(A, T)
-    for i in eachindex(A)
-        out[i] = adjoint(A[i])
-    end
-    return out
-end
+Base.convert{F,A<:Real,B<:Real}(::Type{TapeReal{F}}, val::A, adj::B) = TapeReal{F,promote_type(A,B)}(val, adj)
+Base.convert{F,T<:Real}(::Type{TapeReal{F}}, val::T) = TapeReal{F,T}(val, zero(val))
+Base.convert{F,T<:Real}(::Type{TapeReal{F,T}}, val::Real) = TapeReal{F,T}(T(val), zero(T))
+Base.convert{F,T<:Real}(::Type{TapeReal{F,T}}, n::TapeReal) = TapeReal{F,T}(value(n), adjoint(n))
+Base.convert{F,T<:Real}(::Type{TapeReal{F,T}}, n::TapeReal{F,T}) = n
 
-@inline numtype{tag,T}(::Type{TapeReal{tag,T}}) = T
-@inline tagtype{tag,T}(::Type{TapeReal{tag,T}}) = tag
-
-Base.convert{tag,T<:Real}(::Type{TapeReal{tag,T}}, n::Real) = TapeReal{tag,T}(T(n), zero(T))
-Base.convert{tag,T<:Real}(::Type{TapeReal{tag,T}}, n::TapeReal) = TapeReal{tag,T}(value(n), adjoint(n))
-Base.convert{tag,T<:Real}(::Type{TapeReal{tag,T}}, n::TapeReal{tag,T}) = n
-
-Base.promote_rule{tag,A<:Real,B<:Real}(::Type{A}, ::Type{TapeReal{tag,B}}) = TapeReal{tag,promote_type(A,B)}
-Base.promote_rule{tag,A<:Real,B<:Real}(::Type{TapeReal{tag,A}}, ::Type{TapeReal{tag,B}}) = TapeReal{tag,promote_type(A,B)}
-
-# tape storage #
-#--------------#
-
-abstract AbstractTapeNode
-
-immutable InitialNode <: AbstractTapeNode end
-
-immutable TapeNode{F,I,O} <: AbstractTapeNode
-    f::F
-    inputs::I
-    outputs::O
-    parent::AbstractTapeNode
-end
-
-type TapeHead
-    node::AbstractTapeNode
-end
-
-record!(f, inputs, outputs) = error("no tape defined")
+Base.promote_rule{F,A<:Real,B}(::Type{A}, ::Type{TapeReal{F,B}}) = TapeReal{F,promote_type(A,B)}
+Base.promote_rule{F,A,B}(::Type{TapeReal{F,A}}, ::Type{TapeReal{F,B}}) = TapeReal{F,promote_type(A,B)}
 
 function seed!(head::TapeHead)
-    head.node.outputs.adj = one(head.node.outputs.adj)
+    head.node.output.adj = one(head.node.output.adj)
     return nothing
 end
 
 function backprop!(head::TapeHead)
-    init_node = InitialNode()
     seed!(head)
     current_node = head.node
-    while current_node !== init_node
+    while !(isinit(current_node))
         backprop_rule!(current_node)
         current_node = current_node.parent
     end
     return nothing
 end
 
-function increment_adjoint!{T<:TapeReal, S<:Real}(x::Array{T}, y::Array{S})
-    for i in eachindex(x)
-        x[i].adj += numtype(T)(y[i])
+tape_array{F}(f::F, x) = similar(x, TapeReal{F,eltype(x)})
+
+function load_tape_array!{F,T,N}(tapearr::TapeArray{F,T,N}, arr)
+    for i in eachindex(tapearr)
+        tapearr[i] = TapeReal{F}(arr[i])
+    end
+    return tapearr
+end
+
+function load_adjoint_array!(out, tapearr)
+    for i in eachindex(out)
+        out[i] = adjoint(tapearr[i])
+    end
+    return out
+end
+
+# recording mechanisms #
+#----------------------#
+
+const TAPE_HEAD_CACHE = ObjectIdDict()
+
+function reset_head!{F}(cache, ::F)
+    if haskey(cache, F)
+        head = cache[F]::TapeHead
+        head.node = INITIAL_NODE
+    else
+        head = TapeHead(INITIAL_NODE)
+        cache[F] = head
+    end
+    return head::TapeHead
+end
+
+@generated function record!{F,T}(f, inputs, output::TapeReal{F,T})
+    head = TAPE_HEAD_CACHE[F]::TapeHead
+    return quote
+        $(head).node = TapeNode(f, inputs, output, $(head).node)
+        return output
+    end
+end
+
+@generated function record!{F,T,N}(f, inputs, output::TapeArray{F,T,N})
+    head = TAPE_HEAD_CACHE[F]::TapeHead
+    return quote
+        $(head).node = TapeNode(f, inputs, output, $(head).node)
+        return output
     end
 end
 
@@ -102,85 +120,114 @@ end
 # unary functions #
 #-----------------#
 
-function backprop_rule!{F,T<:TapeReal,S<:TapeReal}(node::TapeNode{F,T,S})
-    node.inputs.adj += adjoint(node.outputs) * ForwardDiff.derivative(node.f, value(node.inputs))
-    return nothing
-end
-
 for (f, _) in Calculus.symbolic_derivatives_1arg()
     @eval begin
-        @inline Base.$(f){tag}(n::TapeReal{tag}) = record!($(f), n, TapeReal(tag, $(f)(value(n))))
+        @inline Base.$(f){F}(n::TapeReal{F}) = record!($(f), n, TapeReal{F}($(f)(value(n))))
     end
 end
 
-Base.:-{tag}(n::TapeReal{tag}) = record!(-, n, TapeReal(tag, -value(n)))
+Base.:-{F}(n::TapeReal{F}) = record!(-, n, TapeReal{F}(-value(n)))
+Base.abs{F}(n::TapeReal{F}) = record!(abs, n, TapeReal{F}(abs(value(n))))
 
 function backprop_rule!{T<:TapeReal,S<:TapeReal}(node::TapeNode{typeof(-),T,S})
-    node.inputs.adj += -adjoint(node.outputs)
+    node.input.adj += -adjoint(node.output)
     return nothing
 end
 
-Base.abs{tag}(n::TapeReal{tag}) = record!(abs, n, TapeReal(tag, abs(value(n))))
-
 function backprop_rule!{T<:TapeReal,S<:TapeReal}(node::TapeNode{typeof(abs),T,S})
-    node.inputs.adj += adjoint(node.outputs) * sign(value(node.inputs))
+    node.input.adj += adjoint(node.output) * sign(value(node.input))
     return nothing
 end
 
 # binary functions #
 #------------------#
 
-function backprop_rule!{F,T<:Tuple,S<:TapeReal}(node::TapeNode{F,T,S})
-    outadj, invals = adjoint(node.outputs), map(value, node.inputs)
-    unary_f = x -> node.f(x...)
-    grad = Vector{numtype(S)}(length(invals))
-    ForwardDiff.gradient!(grad, unary_f, invals)
-    for i in eachindex(invals)
-        node.inputs[i].adj += outadj * grad[i]
-    end
-    return nothing
-end
-
 for f in (:*, :/, :+, :-)
     grad = Calculus.differentiate(:($f(x, y)), [:x, :y])
     @eval begin
-        @inline function Base.$(f){tag}(a::TapeReal{tag}, b::TapeReal{tag})
-            out = TapeReal(tag, $(f)(value(a), value(b)))
-            return record!($(f), tuple(a, b), out)
-        end
+        @inline Base.$(f){F}(a::TapeReal{F}, b::TapeReal{F}) = record!($(f), tuple(a, b), TapeReal{F}($(f)(value(a), value(b))))
 
         function backprop_rule!{T1<:TapeReal,T2<:TapeReal,S<:TapeReal}(node::TapeNode{typeof($f),Tuple{T1,T2},S})
-            adj, x, y = adjoint(node.outputs), value(node.inputs[1]), value(node.inputs[2])
-            node.inputs[1].adj += adj * $(grad[1])
-            node.inputs[2].adj += adj * $(grad[2])
+            adj, x, y = adjoint(node.output), value(node.input[1]), value(node.input[2])
+            node.input[1].adj += adj * $(grad[1])
+            node.input[2].adj += adj * $(grad[2])
             return nothing
         end
     end
 end
 
-# backprop! no-ops #
-#------------------#
+# ForwardDiff fallbacks #
+#-----------------------#
 
+# f(x) -> n
+function backprop_rule!{F,T<:TapeReal,S<:TapeReal}(node::TapeNode{F,T,S})
+    adj, x = adjoint(node.output), value(node.input)
+    node.input.adj += adj * ForwardDiff.derivative(node.f, x)
+    return nothing
+end
+
+# f(x,y) -> n
+function backprop_rule!{F,T1<:TapeReal,T2<:TapeReal,S<:TapeReal}(node::TapeNode{F,Tuple{T1,T2},S})
+    adj, x, y = adjoint(node.output), value(node.input[1]), value(node.input[2])
+    dualx = ForwardDiff.Dual(x, one(x), zero(x))
+    dualy = ForwardDiff.Dual(y, zero(y), one(y))
+    grad = node.f(dualx, dualy)
+    node.input[1].adj += adj * ForwardDiff.partials(grad, 1)
+    node.input[2].adj += adj * ForwardDiff.partials(grad, 2)
+    return nothing
+end
+
+# f(x,y,z) -> n
+function backprop_rule!{F,T1<:TapeReal,T2<:TapeReal,T3<:TapeReal,S<:TapeReal}(node::TapeNode{F,Tuple{T1,T2,T3},S})
+    adj, x, y, z = adjoint(node.output), value(node.input[1]), value(node.input[2]), value(node.input[3])
+    dualx = ForwardDiff.Dual(x, one(x), zero(x), zero(z))
+    dualy = ForwardDiff.Dual(y, zero(y), one(y), zero(z))
+    dualz = ForwardDiff.Dual(z, zero(z), zero(z), one(z))
+    grad = node.f(dualx, dualy, dualz)
+    node.input[1].adj += adj * ForwardDiff.partials(grad, 1)
+    node.input[2].adj += adj * ForwardDiff.partials(grad, 2)
+    node.input[3].adj += adj * ForwardDiff.partials(grad, 3)
+    return nothing
+end
+
+# f(x...) -> n
+function backprop_rule!{F,T<:Tuple,S<:TapeReal}(node::TapeNode{F,T,S})
+    adj, inputs = adjoint(node.output), map(value, node.input)
+    grad = Vector{numtype(S)}(length(inputs))
+    ForwardDiff.gradient!(grad, x -> node.f(x...), inputs)
+    for i in eachindex(grad)
+        node.input[i].adj += adj * grad[i]
+    end
+    return nothing
+end
+
+#############################
+# Special Cases Overloading #
+#############################
+
+# no-ops
 for f in (:(Base.:<), :(Base.:>), :(Base.:(==)), :(Base.:(<=)), :(Base.:(>=)))
     @eval begin
-        @inline $(f){tag}(a::TapeReal{tag}, b::TapeReal{tag}) = TapeReal(tag, $(f)(value(a), value(b)))
+        @inline $(f){F}(a::TapeReal{F}, b::TapeReal{F}) = TapeReal{F}($(f)(value(a), value(b)))
     end
 end
 
-function Base.map{tag,T<:Real}(f, A::Array{TapeReal{tag,T}})
-    out = similar(A)
-    for i in eachindex(A)
-        out[i] = TapeReal{tag,T}(f(A[i].val))
+# map(f, arr) -> out
+function Base.map{F,T,N}(f, arr::TapeArray{F,T,N})
+    out = similar(arr)
+    for i in eachindex(out)
+        out[i] = TapeReal{F,T}(f(value(arr[i])))
     end
-    record!(map, tuple(f, A), out)
+    record!(map, tuple(f, arr), out)
+    return out
 end
 
-function backprop_rule!{F<:Function,T<:Array,S<:Array}(node::TapeNode{typeof(map),Tuple{F,T},S})
-    adj = adjoint(node.outputs)
-    f = node.inputs[1]
+function backprop_rule!{F<:Function,T<:AbstractArray,S<:AbstractArray}(node::TapeNode{typeof(map),Tuple{F,T},S})
+    out, f, arr = node.output, node.input[1], node.input[2]
     df = x -> ForwardDiff.derivative(f, x)
-    A = node.inputs[2]
-    increment_adjoint!(A, adj .* map(df, value(A)))
+    for i in eachindex(arr)
+        arr[i].adj += adjoint(out[i]) * df(value(arr[i]))
+    end
     return nothing
 end
 
@@ -188,40 +235,16 @@ end
 # API #
 #######
 
-gradient(f, x) = gradient(f, Input{eltype(x),length(x)})
-
-function gradient{F,T,N}(f::F, ::Type{Input{T,N}})
-    head = TapeHead(InitialNode())
-    tapevec = Vector{TapeReal{Tag{F,T,N},T}}(N)
-    eval(quote
-        function ReverseDiffPrototype.record!{T}(f, inputs, output::TapeValue{Tag{$F,$T,$N},T})
-            head = $head
-            head.node = TapeNode(f, inputs, output, head.node)
-            return output
-        end
-    end)
-    return (out, x) -> begin
-        load_tapevec!(tapevec, x)
-        f(tapevec)
+function gradient{F}(f::F)
+    head = reset_head!(TAPE_HEAD_CACHE, f)::TapeHead
+    return (out, x, tapearr = tape_array(f, x)) -> begin
+        load_tape_array!(tapearr, x)
+        f(tapearr)
         backprop!(head)
-        head.node = InitialNode()
-        load_adjoint!(out, tapevec)
+        head.node = INITIAL_NODE
+        load_adjoint_array!(out, tapearr)
         return out
     end
-end
-
-function load_tapevec!{F,T,N}(tapevec::Vector{TapeReal{Tag{F,T,N},T}}, x)
-    for i in eachindex(x)
-        tapevec[i] = ReverseDiffPrototype.TapeReal{Tag{F,T,N},T}(x[i], zero(T))
-    end
-    return tapevec
-end
-
-function load_adjoint!(out, tapevec)
-    for i in eachindex(out)
-        out[i] = adjoint(tapevec[i])
-    end
-    return out
 end
 
 end # module

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -12,4 +12,6 @@ end
 
 x = rand(100000);
 out = zeros(x);
-g! = ReverseDiffPrototype.gradient(rosenbrock, Input{Float64,100000});
+t = ReverseDiffPrototype.tape_array(rosenbrock, x)
+g! = ReverseDiffPrototype.gradient(rosenbrock)
+# @time g!(out, x, t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,14 +5,14 @@ using ForwardDiff
 x = rand(5)
 out = zeros(x)
 testf1(x) = (exp(x[1]) + log(x[3]) * x[4]) / x[5]
-g1! = ReverseDiffPrototype.gradient(testf1, x)
+g1! = ReverseDiffPrototype.gradient(testf1)
 
 @test_approx_eq g1!(out, x) ForwardDiff.gradient(testf1, x)
 
 x = rand(2)
 out = zeros(x)
 testf2(x) = x[1]*x[2] + sin(x[1])
-g2! = ReverseDiffPrototype.gradient(testf2, x)
+g2! = ReverseDiffPrototype.gradient(testf2)
 
 @test_approx_eq g2!(out, x) ForwardDiff.gradient(testf2, x)
 
@@ -27,7 +27,7 @@ function testf3(x)
     return trace(log(A * B .+ c))
 end
 
-g3! = ReverseDiffPrototype.gradient(testf3, x)
+g3! = ReverseDiffPrototype.gradient(testf3)
 
 @test_approx_eq g3!(out, x) ForwardDiff.gradient(testf3, x)
 
@@ -40,16 +40,16 @@ function rosenbrock(x)
     end
     return result
 end
-g4! = ReverseDiffPrototype.gradient(rosenbrock, Input{Float64,100})
+g4! = ReverseDiffPrototype.gradient(rosenbrock)
 x = rand(100)
 out = similar(x)
 
 @test_approx_eq g4!(out, x) ForwardDiff.gradient(rosenbrock, x)
 
 # map of univariates
-x = randn(49)
+x = rand(49) # using `rand(1:10, 49)` will cause this test to fail
 out = zeros(x)
-aux_fn5(x) = sqrt(abs(x) + x^2)
+aux_fn5(x) = sqrt(abs(x) + x^2) * 0.5
 function testf5(x)
     k = length(x)
     N = Int(sqrt(k))
@@ -57,5 +57,5 @@ function testf5(x)
     return sum(map(aux_fn5, A))
 end
 
-g5! = ReverseDiffPrototype.gradient(testf5, x)
+g5! = ReverseDiffPrototype.gradient(testf5)
 @test_approx_eq g5!(out, x) ForwardDiff.gradient(testf5, x)


### PR DESCRIPTION
This makes the API more flexible (no need to specify input type/dimension), and avoids a class of eval-related bugs I found (i.e. nothing works until you get back to top-level, method overwriting improperly initialized the tape head, etc.). 

Additionally, I rewrote `map` to use fewer temporaries, and hardcoded the two-arg and three-arg ForwardDiff fallback `backprop_rule!` definitions to avoid temporary vectors (the generic gradient fallback still allocates a `Vector` and reverts to splatting).

I also realized a conversion-related bug that I'll file an issue for, but is outside the scope of this PR.

EDIT: This PR also enables Travis.