### PR TITLE
add optimizations of matrix ops

### DIFF
--- a/test/matrixfun.jl
+++ b/test/matrixfun.jl
@@ -1,0 +1,16 @@
+using ReverseDiffPrototype
+
+const N = 100
+x = rand(2N^2 + N)
+function matrixnode(x)
+    k = length(x)
+    A = reshape(x[1:N^2], N, N)
+    B = reshape(x[N^2 + 1:2N^2], N, N)
+    c = x[2N^2+1:end]
+    return trace(log(A * B .+ c))
+end
+
+out = zeros(x);
+t = ReverseDiffPrototype.tape_array(matrixnode, x)
+g! = ReverseDiffPrototype.gradient(matrixnode)
+@time g!(out, x, t)


### PR DESCRIPTION
I decided to do some timing of my original objective function involving some matrix ops for comparison. By adding some specific rules for handling `*`, I got a 50x speedup over master, which is not entirely surprising. It does suggest, though, that we might want to be sure that approaches like #10 allow for these same kinds of optimizations. My intuition, again, is that unlike in JuMP, a lot of the applications ML people have in mind consist of pretty small graphs with "fat" nodes.

Timing:
(master, without matrix ops)
```
0.179432 seconds (6.17 M allocations: 188.689 MB)
20100-element Array{Float64,1}
```

this branch:
```
0.003167 seconds (80.46 k allocations: 3.448 MB)
20100-element Array{Float64,1}
```