### PR TITLE
add jacobian methods and fix #16

### DIFF
--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -4,15 +4,7 @@ const N = 100000
 
 println("benchmarking rosenbrock(x)...")
 
-function rosenbrock(x)
-    a = one(eltype(x))
-    b = 100 * a
-    result = zero(eltype(x))
-    for i in 1:length(x)-1
-        result += (a - x[i])^2 + b*(x[i+1] - x[i]^2)^2
-    end
-    return result
-end
+rosenbrock(x) = sum(@diffpure map((i, j) -> (1 - j)^2 + 100*(i - j^2)^2, x[2:end], x[1:end-1]))
 
 x = rand(N);
 out = zeros(x);

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -4,7 +4,7 @@ const N = 100000
 
 println("benchmarking rosenbrock(x)...")
 
-rosenbrock(x) = sum(@diffpure map((i, j) -> (1 - j)^2 + 100*(i - j^2)^2, x[2:end], x[1:end-1]))
+rosenbrock(x) = sum(@fastdiff map((i, j) -> (1 - j)^2 + 100*(i - j^2)^2, x[2:end], x[1:end-1]))
 
 x = rand(N);
 out = zeros(x);

--- a/benchmark/old_matrix_test.jl
+++ b/benchmark/old_matrix_test.jl
@@ -12,4 +12,5 @@ end
 
 out = zeros(x);
 t = ReverseDiffPrototype.trace_array(typeof(matrix_test), eltype(out), x);
+ReverseDiffPrototype.gradient!(out, matrix_test, x, t); # warmup
 @time ReverseDiffPrototype.gradient!(out, matrix_test, x, t);

--- a/src/ReverseDiffPrototype.jl
+++ b/src/ReverseDiffPrototype.jl
@@ -2,11 +2,14 @@ module ReverseDiffPrototype
 
 using ForwardDiff
 using Base.RefValue
+
 import ForwardDiff: Dual, Partials, value, partials
 
 include("TraceReal.jl")
 include("array.jl")
 include("trace.jl")
 include("api.jl")
+
+export @diffpure
 
 end # module

--- a/src/ReverseDiffPrototype.jl
+++ b/src/ReverseDiffPrototype.jl
@@ -10,6 +10,6 @@ include("array.jl")
 include("trace.jl")
 include("api.jl")
 
-export @diffpure
+export @fastdiff
 
 end # module

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,13 +1,49 @@
+######################
+# gradient/gradient! #
+######################
+
 function gradient{F}(f::F, x, tracex = trace_array(F, eltype(x), x))
     trace = reset_trace!(F)
-    f(tracex)
+    seed!(f(tracex))
     backprop!(trace)
     return adjoint(tracex)
 end
 
 function gradient!{F}(out, f::F, x, tracex = trace_array(F, eltype(out), x))
     trace = reset_trace!(F)
-    f(tracex)
+    seed!(f(tracex))
     backprop!(trace)
     return adjoint!(out, tracex)
+end
+
+######################
+# jacobian/jacobian! #
+######################
+
+function load_jacobian!(out, tracex, y, trace)
+    for i in eachindex(y)
+        n = y[i]
+        seed!(n)
+        backprop!(trace)
+        for j in eachindex(tracex)
+            m = tracex[j]
+            out[i, j] = adjoint(m)
+            unseed!(m)
+        end
+        unseed!(n)
+    end
+    return out
+end
+
+function jacobian{F}(f::F, x, tracex = trace_array(F, eltype(x), x))
+    trace = reset_trace!(F)
+    y = f(tracex)
+    out = similar(y, eltype(x), length(y), length(x))
+    return load_jacobian!(out, tracex, y, trace)
+end
+
+function jacobian!{F}(out, f::F, x, tracex = trace_array(F, eltype(out), x))
+    trace = reset_trace!(F)
+    y = f(tracex)
+    return load_jacobian!(out, tracex, y, trace)
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -45,5 +45,6 @@ end
 function jacobian!{F}(out, f::F, x, tracex = trace_array(F, eltype(out), x))
     trace = reset_trace!(F)
     y = f(tracex)
-    return load_jacobian!(out, tracex, y, trace)
+    load_jacobian!(reshape(out, length(y), length(x)), tracex, y, trace)
+    return out
 end

--- a/test/MiscTests.jl
+++ b/test/MiscTests.jl
@@ -54,7 +54,7 @@ function test4(x)
     k = length(x)
     N = isqrt(k)
     A = reshape(x, N, N)
-    return sum(@diffpure map(n -> sqrt(abs(n) + n^2) * 0.5, A))
+    return sum(@fastdiff map(n -> sqrt(abs(n) + n^2) * 0.5, A))
 end
 
 Main.testprintln(test4)
@@ -86,7 +86,7 @@ out = similar(x)
 function rosenbrock2(x)
     a = x[1]
     b = 100 * a
-    v = sum(map((i, j) -> (a - j)^2 + b*(i - j^2)^2, x[2:end], x[1:end-1]))
+    v = map((i, j) -> (a - j)^2 + b*(i - j^2)^2, x[2:end], x[1:end-1])
     return sum(v)
 end
 

--- a/test/MiscTests.jl
+++ b/test/MiscTests.jl
@@ -54,7 +54,7 @@ function test4(x)
     k = length(x)
     N = isqrt(k)
     A = reshape(x, N, N)
-    return sum(map(n -> sqrt(abs(n) + n^2) * 0.5, A))
+    return sum(@diffpure map(n -> sqrt(abs(n) + n^2) * 0.5, A))
 end
 
 Main.testprintln(test4)
@@ -62,10 +62,10 @@ Main.testprintln(test4)
 @test_approx_eq RDP.gradient!(out, test4, x) ForwardDiff.gradient(test4, x)
 
 ##################################################
-x = rand(100)
+x = rand(10)
 out = similar(x)
 
-function rosenbrock(x)
+function rosenbrock1(x)
     a = one(eltype(x))
     b = 100 * a
     result = zero(eltype(x))
@@ -75,8 +75,23 @@ function rosenbrock(x)
     return result
 end
 
-Main.testprintln(rosenbrock)
+Main.testprintln(rosenbrock1)
 
-@test_approx_eq RDP.gradient!(out, rosenbrock, x) ForwardDiff.gradient(rosenbrock, x)
+@test_approx_eq RDP.gradient!(out, rosenbrock1, x) ForwardDiff.gradient(rosenbrock1, x)
+
+##################################################
+x = rand(10)
+out = similar(x)
+
+function rosenbrock2(x)
+    a = x[1]
+    b = 100 * a
+    v = sum(map((i, j) -> (a - j)^2 + b*(i - j^2)^2, x[2:end], x[1:end-1]))
+    return sum(v)
+end
+
+Main.testprintln(rosenbrock2)
+
+@test_approx_eq RDP.gradient!(out, rosenbrock2, x) ForwardDiff.gradient(rosenbrock2, x)
 
 end # module


### PR DESCRIPTION
I had already prepared the jacobian stuff when I found the bug from #16, so I just rolled the proposed macro into this PR.

~~I settled on `@diffpure` as the macro name, since it's a differentiation optimization for pure functions.~~ Changed it to `@fastdiff`, inspired by the existing `@fastmath` in Base. It also means we can use it for other optimizations in the future, since we're not tying it to purity-based optimizations. Feel free to bikeshed the name.

